### PR TITLE
Extra steps to build epub?

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ bash$ ./go.sh
 Then use `sbt` to build the book:
 
 ~~~
+npm install grunt
+npm install
 sbt pdf
 ~~~
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.tpolecat" % "tut-plugin" % "0.4.5-SNAPSHOT")
+addSbtPlugin("org.tpolecat" % "tut-plugin" % "0.4.4")


### PR DESCRIPTION
Not sure it's relevant for all configs but these are the two extra steps I had to go through in order to successfully build the epub:
- revert to version 0.4.4 of tut (couldn't fetch the 0.4.5-SNAPSHOT)
- install grunt and the dependencies through npm in the docker container
