### PR TITLE
Fix issue #19

### DIFF
--- a/src/pages/type-level-programming/dependent-functions.md
+++ b/src/pages/type-level-programming/dependent-functions.md
@@ -290,10 +290,10 @@ We can use `IsHCons` instead of `=:=`:
 ```tut:book:silent
 import shapeless.ops.hlist.IsHCons
 
-def getWrappedValue[A, Repr <: HList, Head, Tail <: HList](in: A)(
+def getWrappedValue[A, Repr <: HList, Head](in: A)(
   implicit
   gen: Generic.Aux[A, Repr],
-  isHCons: IsHCons.Aux[Repr, Head, Tail]
+  isHCons: IsHCons.Aux[Repr, Head, HNil]
 ): Head = gen.to(in).head
 ```
 


### PR DESCRIPTION
I thought I might as well send a pull request myself.

I think that 

```scala
def getWrappedValue[A, Repr <: HList, Head](in: A)(
  implicit
  gen: Generic.Aux[A, Repr],
  isHCons: IsHCons.Aux[Repr, Head, HNil]
): Head = gen.to(in).head
```

is also clearer than what I proposed first:

```scala
def getWrappedValue[A, Repr <: HList, Head, Tail <: HList](in: A)(
  implicit
  gen: Generic.Aux[A, Repr],
  isHCons: IsHCons.Aux[Repr, Head, Tail],
  ev: Tail =:= HNil
): Head = gen.to(in).head
```