### PR TITLE
Remove hlist upper bound from genricObjectEncoder

### DIFF
--- a/src/pages/labelled-generic/products.md
+++ b/src/pages/labelled-generic/products.md
@@ -231,7 +231,7 @@ except that we're using `LabelledGeneric` instead of `Generic`:
 ```tut:book:silent
 import shapeless.LabelledGeneric
 
-implicit def genericObjectEncoder[A, H <: HList](
+implicit def genericObjectEncoder[A, H](
   implicit
   generic: LabelledGeneric.Aux[A, H],
   hEncoder: Lazy[JsonObjectEncoder[H]]


### PR DESCRIPTION
If that upper bound is in place the method will not work for a sealed trait because in that case the Repr is of type Coproduct and not HList