### PR TITLE
Fix #30 (change single quotes to not a string literal)

### DIFF
--- a/src/template/template.tex
+++ b/src/template/template.tex
@@ -328,7 +328,6 @@ $endif$
   morecomment=[l]{//},
   morecomment=[n]{/*}{*/},
   morestring=[b]",
-  morestring=[b]',
   morestring=[b]"""
 }
 


### PR DESCRIPTION
### Abstract

I fix #30. In LaTeX highlighting, I change '(single quotes) to a letter that is not a string literal, so if you use single quotes as string literals in this document, highlighting single quote string literals does not work.

### Screenshot

<img width="610" alt="image" src="https://cloud.githubusercontent.com/assets/612043/23336715/32d67b1c-fc1b-11e6-9f96-928913948f29.png">
