### PR TITLE
Prefer spelling of zero to arabic numeral

### DIFF
--- a/src/pages/representations/products.md
+++ b/src/pages/representations/products.md
@@ -8,8 +8,8 @@ that make them unsuitable for shapeless' purposes:
  1. Each size of tuple has a different, unrelated type,
     making it difficult to write code that abstracts over sizes.
 
- 2. There is no type for 0-length tuples,
-    which are important for representing products with 0 fields.
+ 2. There is no type for zero-length tuples,
+    which are important for representing products with zero fields.
     We could arguably use `Unit`,
     but we ideally want all generic representations
     to have a sensible common supertype.


### PR DESCRIPTION
For whatever reason, "0-length" was disruptive when I was reading it with the font used in the PDF