### PR TITLE
Added a missing HList constraint to genericEncoder

### DIFF
--- a/src/pages/generic/products.md
+++ b/src/pages/generic/products.md
@@ -175,7 +175,7 @@ to introduce a new type parameter to our method
 and refer to it in each of the associated value parameters:
 
 ```tut:book:silent
-implicit def genericEncoder[A, R](
+implicit def genericEncoder[A, R <: HList](
   implicit
   gen: Generic[A] { type Repr = R },
   enc: CsvEncoder[R]


### PR DESCRIPTION
In the comment, it says:  *Given a type `A` and an `HList` type `R`*, but `R` isn't constrainted to `HList`. Added the constraint.