### PR TITLE
Fix "hlistSecond" example return type

### DIFF
--- a/src/pages/type-level-programming/dependent-functions.md
+++ b/src/pages/type-level-programming/dependent-functions.md
@@ -131,7 +131,9 @@ import Second._
 ```
 
 ```tut:book:silent
-implicit def hlistSecond[A, B, Rest <: HList]: Second.Aux[A :: B :: Rest, B] =
+import Second.Aux
+
+implicit def hlistSecond[A, B, Rest <: HList]: Aux[A :: B :: Rest, B] =
   new Second[A :: B :: Rest] {
     type Out = B
     def apply(value: A :: B :: Rest): B =

--- a/src/pages/type-level-programming/dependent-functions.md
+++ b/src/pages/type-level-programming/dependent-functions.md
@@ -131,7 +131,7 @@ import Second._
 ```
 
 ```tut:book:silent
-implicit def hlistSecond[A, B, Rest <: HList]: Aux[A :: B :: Rest, B] =
+implicit def hlistSecond[A, B, Rest <: HList]: Second.Aux[A :: B :: Rest, B] =
   new Second[A :: B :: Rest] {
     type Out = B
     def apply(value: A :: B :: Rest): B =


### PR DESCRIPTION
As in title, th return type should be `Second.Aux`

EDIT: Unless this code example should be inside the `Second` object, which was not obvious to me at first glance.